### PR TITLE
fix(matches): recompute division standings on every match edit

### DIFF
--- a/padel_league/modules/frontend_api/v1/matches.py
+++ b/padel_league/modules/frontend_api/v1/matches.py
@@ -67,13 +67,20 @@ def edit_match(id):
         h, a = int(home_games), int(away_games)
         match.winner = 1 if h > a else (-1 if a > h else 0)
         if not match.played:
-            try:
-                match.division.add_match_to_table(match)
-            except Exception:
-                pass
             match.played = True
 
     match.save()
+
+    # Always recompute the division standings from scratch so re-edits to
+    # an already-played match update points/wins/games. add_match_to_table
+    # was incremental and gated on first-time edits, leaving classification
+    # stale on every subsequent edit.
+    if home_games is not None and away_games is not None:
+        try:
+            match.division.update_table(force_update=True)
+        except Exception:
+            pass
+
     return jsonify(serialize_match(match))
 
 

--- a/padel_league/modules/matches.py
+++ b/padel_league/modules/matches.py
@@ -118,10 +118,15 @@ def edit(id):
         )
         match.field = match_field
         if not match.played:
-            match.division.add_match_to_table(match)
-            # match.division.edition.league.ranking_add_match(match)
             match.played = True
         match.save()
+        # Recompute standings from scratch — handles both first-time edits
+        # and re-edits of an already-played match (the previous incremental
+        # add_match_to_table call only ran once per match).
+        try:
+            match.division.update_table(force_update=True)
+        except Exception:
+            pass
 
         return redirect(
             url_for("matches.match", id=match.id, edited_match="edited_match")


### PR DESCRIPTION
## Problem
Editing an already-played match left the division standings stale. The match row was updated (`gamesHomeTeam`, `gamesAwayTeam`, `winner`) but the player relations (`points`, `wins`, `draws`, `losts`, `gamesWon`, `gamesLost`) were not touched on re-edits.

Root cause: both edit handlers gated the standings update on `if not match.played:` because `add_match_to_table` is incremental (`relation.points += points`, etc.) and would double-count on re-edits.

This shows up in the React UI as well — the new Editar Jogos toggle on the Resultados tab calls `POST /api/v1/matches/<id>/edit`, so without this fix the toggle could change a score but the classification table on the General tab would not reflect the change.

## Fix
Replace the gated incremental call with `division.update_table(force_update=True)` (already exists in `models/divisions.py`). It recomputes every player relation from the actual match data via `matches_won/drawn/lost` and `games_won/lost` — fully idempotent.

Applied to both edit paths:
- `POST /api/v1/matches/<id>/edit` — used by the React `EditableMatchCard` (Editar Jogos toggle, Editar jogos tab, Shuffle is unaffected — it already calls `recalculate_player_stats`).
- `POST /matches/<id>/edit` — Jinja admin editor.

## Verification
Local Postgres, tournament 65, match 2653 (1-7 → Falcão wins):

| Event | Falcão | António Maria |
|---|---|---|
| Original | 42 pts | 32 pts |
| Flip to 7-1 (post-fix) | 39 pts (-3) | 35 pts (+3) |
| Restore to 1-7 | 42 pts | 32 pts |

The recompute also corrected pre-existing drift in unrelated players (e.g. João Leite went from 28 → 22 after the flip and stayed at 22 after restore, because the stored value had drifted from the actual match data over prior incremental updates). Deploying this PR will trigger that one-time correction the next time any match in a division is edited.

## Notes
- `add_match_to_table` is no longer called from `edit_match`; it's still used by the create-match flow in `modules/matches.py:create`, which is fine — that path runs exactly once per match.
- `update_table` already handles end-of-division side effects (`has_ended`, league ranking update) and is safely re-entrant for already-ended divisions.